### PR TITLE
chore: update groupId in documentation and fix test assertions

### DIFF
--- a/dify/dify-client/dify-client-integration/dify-client-integration-spring/src/spring6Test/java/io/github/guoshiqiufeng/dify/client/integration/spring/http/Spring6HttpClientIntegrationTest.java
+++ b/dify/dify-client/dify-client-integration/dify-client-integration-spring/src/spring6Test/java/io/github/guoshiqiufeng/dify/client/integration/spring/http/Spring6HttpClientIntegrationTest.java
@@ -393,8 +393,8 @@ class Spring6HttpClientIntegrationTest {
 
         // Assert
         RecordedRequest request = mockServer.takeRequest();
-        assertNotNull(request.getHeader("X-API-Key"));
-        assertNotNull(request.getHeader("X-Client-Version"));
+        assertNotNull(request.getHeaders().get("X-API-Key"));
+        assertNotNull(request.getHeaders().get("X-Client-Version"));
     }
 
     @Test
@@ -416,7 +416,7 @@ class Spring6HttpClientIntegrationTest {
 
         // Assert
         RecordedRequest request = mockServer.takeRequest();
-        assertEquals("application/json", request.getHeader("Accept"));
+        assertEquals("application/json", request.getHeaders().get("Accept"));
     }
 
     // ========== WebClient Tests ==========
@@ -660,8 +660,8 @@ class Spring6HttpClientIntegrationTest {
 
         // Assert
         RecordedRequest request = mockServer.takeRequest();
-        assertEquals("Bearer token123", request.getHeader("Authorization"));
-        assertEquals("req-456", request.getHeader("X-Request-ID"));
+        assertEquals("Bearer token123", request.getHeaders().get("Authorization"));
+        assertEquals("req-456", request.getHeaders().get("X-Request-ID"));
     }
 
     @Test

--- a/docs/en/guide/status.md
+++ b/docs/en/guide/status.md
@@ -29,8 +29,8 @@ Add dependencies to your `build.gradle`:
 
 ```gradle:no-line-numbers:no-v-pre
 dependencies {
-    implementation 'io.github.guoshiqiufeng:dify-spring-boot-starter:{{version}}'
-    implementation 'io.github.guoshiqiufeng:dify-status:{{version}}'
+    implementation 'io.github.guoshiqiufeng.dify:dify-spring-boot-starter:{{version}}'
+    implementation 'io.github.guoshiqiufeng.dify:dify-status:{{version}}'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 ```
@@ -40,12 +40,12 @@ Or add to your `pom.xml`:
 ```xml:no-line-numbers:no-v-pre
 <dependencies>
     <dependency>
-        <groupId>io.github.guoshiqiufeng</groupId>
+        <groupId>io.github.guoshiqiufeng.dify</groupId>
         <artifactId>dify-spring-boot-starter</artifactId>
         <version>{{version}}</version>
     </dependency>
     <dependency>
-        <groupId>io.github.guoshiqiufeng</groupId>
+        <groupId>io.github.guoshiqiufeng.dify</groupId>
         <artifactId>dify-status</artifactId>
         <version>{{version}}</version>
     </dependency>

--- a/docs/guide/status.md
+++ b/docs/guide/status.md
@@ -29,8 +29,8 @@ const version = inject('version');
 
 ```gradle:no-line-numbers:no-v-pre
 dependencies {
-    implementation 'io.github.guoshiqiufeng:dify-spring-boot-starter:{{version}}'
-    implementation 'io.github.guoshiqiufeng:dify-status:{{version}}'
+    implementation 'io.github.guoshiqiufeng.dify:dify-spring-boot-starter:{{version}}'
+    implementation 'io.github.guoshiqiufeng.dify:dify-status:{{version}}'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 ```
@@ -40,12 +40,12 @@ dependencies {
 ```xml:no-line-numbers:no-v-pre
 <dependencies>
     <dependency>
-        <groupId>io.github.guoshiqiufeng</groupId>
+        <groupId>io.github.guoshiqiufeng.dify</groupId>
         <artifactId>dify-spring-boot-starter</artifactId>
         <version>{{version}}</version>
     </dependency>
     <dependency>
-        <groupId>io.github.guoshiqiufeng</groupId>
+        <groupId>io.github.guoshiqiufeng.dify</groupId>
         <artifactId>dify-status</artifactId>
         <version>{{version}}</version>
     </dependency>


### PR DESCRIPTION
- Update Maven groupId from io.github.guoshiqiufeng to io.github.guoshiqiufeng.dify in status docs
- Fix Spring6HttpClientIntegrationTest to use getHeaders().get() instead of deprecated getHeader() method

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #287 

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`,
>
see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> for more details.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic
  change.
- [x] I've updated the documentation accordingly.
