### PR TITLE
feat: add new fields to file upload response DTOs

### DIFF
--- a/dify/dify-support/dify-support-chat/src/main/java/io/github/guoshiqiufeng/dify/chat/dto/response/FileUploadResponse.java
+++ b/dify/dify-support/dify-support-chat/src/main/java/io/github/guoshiqiufeng/dify/chat/dto/response/FileUploadResponse.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
  */
 @Data
 public class FileUploadResponse implements Serializable {
-    private static final long serialVersionUID = 135249636075831292L;
+    private static final long serialVersionUID = 135249636075831293L;
 
     private String id;
 
@@ -57,4 +57,46 @@ public class FileUploadResponse implements Serializable {
      */
     @JsonAlias("created_at")
     private Long createdAt;
+
+    /**
+     * 预览 URL
+     */
+    @JsonAlias("preview_url")
+    private String previewUrl;
+
+    /**
+     * 源 URL
+     */
+    @JsonAlias("source_url")
+    private String sourceUrl;
+
+    /**
+     * 原始 URL
+     */
+    @JsonAlias("original_url")
+    private String originalUrl;
+
+    /**
+     * 用户 ID
+     */
+    @JsonAlias("user_id")
+    private String userId;
+
+    /**
+     * 租户 ID
+     */
+    @JsonAlias("tenant_id")
+    private String tenantId;
+
+    /**
+     * 会话 ID
+     */
+    @JsonAlias("conversation_id")
+    private String conversationId;
+
+    /**
+     * 文件存储键
+     */
+    @JsonAlias("file_key")
+    private String fileKey;
 }

--- a/dify/dify-support/dify-support-dataset/src/main/java/io/github/guoshiqiufeng/dify/dataset/dto/response/UploadFileInfoResponse.java
+++ b/dify/dify-support/dify-support-dataset/src/main/java/io/github/guoshiqiufeng/dify/dataset/dto/response/UploadFileInfoResponse.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
  */
 @Data
 public class UploadFileInfoResponse implements Serializable {
-    private static final long serialVersionUID = 487590129337348606L;
+    private static final long serialVersionUID = 487590129337348607L;
 
     private String id;
     private String name;
@@ -36,11 +36,53 @@ public class UploadFileInfoResponse implements Serializable {
     private String url;
     @JsonAlias("download_url")
     private String downloadUrl;
-    @JsonAlias("mine_type")
+    @JsonAlias("mime_type")
     private String mimeType;
     @JsonAlias("created_by")
     private String createdBy;
     @JsonAlias("created_at")
     private Long createdAt;
+
+    /**
+     * 预览 URL
+     */
+    @JsonAlias("preview_url")
+    private String previewUrl;
+
+    /**
+     * 源 URL
+     */
+    @JsonAlias("source_url")
+    private String sourceUrl;
+
+    /**
+     * 原始 URL
+     */
+    @JsonAlias("original_url")
+    private String originalUrl;
+
+    /**
+     * 用户 ID
+     */
+    @JsonAlias("user_id")
+    private String userId;
+
+    /**
+     * 租户 ID
+     */
+    @JsonAlias("tenant_id")
+    private String tenantId;
+
+    /**
+     * 会话 ID
+     */
+    @JsonAlias("conversation_id")
+    private String conversationId;
+
+    /**
+     * 文件存储键
+     */
+    @JsonAlias("file_key")
+    private String fileKey;
 
 }

--- a/dify/dify-support/dify-support-dataset/src/test/java/io/github/guoshiqiufeng/dify/dataset/dto/response/UploadFileInfoResponseTest.java
+++ b/dify/dify-support/dify-support-dataset/src/test/java/io/github/guoshiqiufeng/dify/dataset/dto/response/UploadFileInfoResponseTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.guoshiqiufeng.dify.chat.dto.response;
+package io.github.guoshiqiufeng.dify.dataset.dto.response;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,13 +22,13 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test class for FileUploadResponse
+ * Test class for UploadFileInfoResponse
  *
  * @author yanghq
  * @version 1.0
- * @since 2025/5/2
+ * @since 2025/5/20
  */
-public class FileUploadResponseTest {
+public class UploadFileInfoResponseTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -38,7 +38,7 @@ public class FileUploadResponseTest {
     @Test
     public void testDefaultConstructor() {
         // Act
-        FileUploadResponse response = new FileUploadResponse();
+        UploadFileInfoResponse response = new UploadFileInfoResponse();
 
         // Assert
         assertNotNull(response);
@@ -46,6 +46,8 @@ public class FileUploadResponseTest {
         assertNull(response.getName());
         assertNull(response.getSize());
         assertNull(response.getExtension());
+        assertNull(response.getUrl());
+        assertNull(response.getDownloadUrl());
         assertNull(response.getMimeType());
         assertNull(response.getCreatedBy());
         assertNull(response.getCreatedAt());
@@ -64,11 +66,13 @@ public class FileUploadResponseTest {
     @Test
     public void testGetterAndSetter() {
         // Arrange
-        FileUploadResponse response = new FileUploadResponse();
+        UploadFileInfoResponse response = new UploadFileInfoResponse();
         String id = "file-12345";
         String name = "test-file.pdf";
         Integer size = 12345;
         String extension = "pdf";
+        String url = "https://example.com/file-12345";
+        String downloadUrl = "https://example.com/download/file-12345";
         String mimeType = "application/pdf";
         String createdBy = "user-12345";
         Long createdAt = 1651234567890L;
@@ -85,6 +89,8 @@ public class FileUploadResponseTest {
         response.setName(name);
         response.setSize(size);
         response.setExtension(extension);
+        response.setUrl(url);
+        response.setDownloadUrl(downloadUrl);
         response.setMimeType(mimeType);
         response.setCreatedBy(createdBy);
         response.setCreatedAt(createdAt);
@@ -101,6 +107,8 @@ public class FileUploadResponseTest {
         assertEquals(name, response.getName());
         assertEquals(size, response.getSize());
         assertEquals(extension, response.getExtension());
+        assertEquals(url, response.getUrl());
+        assertEquals(downloadUrl, response.getDownloadUrl());
         assertEquals(mimeType, response.getMimeType());
         assertEquals(createdBy, response.getCreatedBy());
         assertEquals(createdAt, response.getCreatedAt());
@@ -119,11 +127,13 @@ public class FileUploadResponseTest {
     @Test
     public void testJsonSerialization() throws JsonProcessingException {
         // Create an instance with sample data
-        FileUploadResponse response = new FileUploadResponse();
+        UploadFileInfoResponse response = new UploadFileInfoResponse();
         response.setId("file-12345");
         response.setName("test-file.pdf");
         response.setSize(12345);
         response.setExtension("pdf");
+        response.setUrl("https://example.com/file-12345");
+        response.setDownloadUrl("https://example.com/download/file-12345");
         response.setMimeType("application/pdf");
         response.setCreatedBy("user-12345");
         response.setCreatedAt(1651234567890L);
@@ -136,6 +146,8 @@ public class FileUploadResponseTest {
         assertTrue(json.contains("\"name\":"));
         assertTrue(json.contains("\"size\":"));
         assertTrue(json.contains("\"extension\":"));
+        assertTrue(json.contains("\"url\":"));
+        assertTrue(json.contains("\"downloadUrl\":"));
         assertTrue(json.contains("\"mimeType\":"));
         assertTrue(json.contains("\"createdBy\":"));
         assertTrue(json.contains("\"createdAt\":"));
@@ -148,20 +160,22 @@ public class FileUploadResponseTest {
         assertTrue(json.contains("\"fileKey\":"));
 
         // Deserialize back to object
-        FileUploadResponse deserialized = objectMapper.readValue(json, FileUploadResponse.class);
+        UploadFileInfoResponse deserialized = objectMapper.readValue(json, UploadFileInfoResponse.class);
 
         // Verify the deserialized object matches the original
         assertEquals(response.getId(), deserialized.getId());
         assertEquals(response.getName(), deserialized.getName());
         assertEquals(response.getSize(), deserialized.getSize());
         assertEquals(response.getExtension(), deserialized.getExtension());
+        assertEquals(response.getUrl(), deserialized.getUrl());
+        assertEquals(response.getDownloadUrl(), deserialized.getDownloadUrl());
         assertEquals(response.getMimeType(), deserialized.getMimeType());
         assertEquals(response.getCreatedBy(), deserialized.getCreatedBy());
         assertEquals(response.getCreatedAt(), deserialized.getCreatedAt());
     }
 
     /**
-     * Test JSON deserialization with aliases
+     * Test JSON deserialization with aliases (including mime_type bug fix)
      */
     @Test
     public void testJsonDeserialization() throws JsonProcessingException {
@@ -171,6 +185,8 @@ public class FileUploadResponseTest {
                 "  \"name\": \"test-file.pdf\",\n" +
                 "  \"size\": 12345,\n" +
                 "  \"extension\": \"pdf\",\n" +
+                "  \"url\": \"https://example.com/file-12345\",\n" +
+                "  \"download_url\": \"https://example.com/download/file-12345\",\n" +
                 "  \"mime_type\": \"application/pdf\",\n" +
                 "  \"created_by\": \"user-12345\",\n" +
                 "  \"created_at\": 1651234567890,\n" +
@@ -184,13 +200,15 @@ public class FileUploadResponseTest {
                 "}";
 
         // Deserialize with aliases
-        FileUploadResponse deserialized = objectMapper.readValue(jsonWithAliases, FileUploadResponse.class);
+        UploadFileInfoResponse deserialized = objectMapper.readValue(jsonWithAliases, UploadFileInfoResponse.class);
 
         // Verify fields were correctly deserialized
         assertEquals("file-12345", deserialized.getId());
         assertEquals("test-file.pdf", deserialized.getName());
         assertEquals(Integer.valueOf(12345), deserialized.getSize());
         assertEquals("pdf", deserialized.getExtension());
+        assertEquals("https://example.com/file-12345", deserialized.getUrl());
+        assertEquals("https://example.com/download/file-12345", deserialized.getDownloadUrl());
         assertEquals("application/pdf", deserialized.getMimeType());
         assertEquals("user-12345", deserialized.getCreatedBy());
         assertEquals(Long.valueOf(1651234567890L), deserialized.getCreatedAt());
@@ -209,11 +227,13 @@ public class FileUploadResponseTest {
     @Test
     public void testEqualsAndHashCode() {
         // Create two identical objects
-        FileUploadResponse response1 = new FileUploadResponse();
+        UploadFileInfoResponse response1 = new UploadFileInfoResponse();
         response1.setId("file-12345");
         response1.setName("test-file.pdf");
         response1.setSize(12345);
         response1.setExtension("pdf");
+        response1.setUrl("https://example.com/file-12345");
+        response1.setDownloadUrl("https://example.com/download/file-12345");
         response1.setMimeType("application/pdf");
         response1.setCreatedBy("user-12345");
         response1.setCreatedAt(1651234567890L);
@@ -225,11 +245,13 @@ public class FileUploadResponseTest {
         response1.setConversationId("conv-456def");
         response1.setFileKey("uploads/test-file.pdf");
 
-        FileUploadResponse response2 = new FileUploadResponse();
+        UploadFileInfoResponse response2 = new UploadFileInfoResponse();
         response2.setId("file-12345");
         response2.setName("test-file.pdf");
         response2.setSize(12345);
         response2.setExtension("pdf");
+        response2.setUrl("https://example.com/file-12345");
+        response2.setDownloadUrl("https://example.com/download/file-12345");
         response2.setMimeType("application/pdf");
         response2.setCreatedBy("user-12345");
         response2.setCreatedAt(1651234567890L);
@@ -242,11 +264,13 @@ public class FileUploadResponseTest {
         response2.setFileKey("uploads/test-file.pdf");
 
         // Create a different object
-        FileUploadResponse response3 = new FileUploadResponse();
+        UploadFileInfoResponse response3 = new UploadFileInfoResponse();
         response3.setId("file-67890");
         response3.setName("other-file.txt");
         response3.setSize(5678);
         response3.setExtension("txt");
+        response3.setUrl("https://example.com/file-67890");
+        response3.setDownloadUrl("https://example.com/download/file-67890");
         response3.setMimeType("text/plain");
         response3.setCreatedBy("user-67890");
         response3.setCreatedAt(1650123456789L);

--- a/docs/en/guide/feature/chat.md
+++ b/docs/en/guide/feature/chat.md
@@ -621,6 +621,13 @@ FileUploadResponse
 | mimeType       | String  | File MIME type     |
 | createdBy      | String  | Creator            |
 | createdAt      | Long    | Creation timestamp |
+| previewUrl     | String  | Preview URL        |
+| sourceUrl      | String  | Source URL         |
+| originalUrl    | String  | Original URL       |
+| userId         | String  | User ID            |
+| tenantId       | String  | Tenant ID          |
+| conversationId | String  | Conversation ID    |
+| fileKey        | String  | File storage key   |
 
 ### 3.5 Get Application Info
 

--- a/docs/en/guide/feature/dataset.md
+++ b/docs/en/guide/feature/dataset.md
@@ -687,17 +687,24 @@ UploadFileInfoResponse uploadFileInfo(String datasetId, String documentId, Strin
 
 UploadFileInfoResponse
 
-| Parameter   | Type    | Description        |
-|-------------|---------|--------------------|
-| id          | String  | File ID            |
-| name        | String  | File name          |
-| size        | Integer | File size          |
-| extension   | String  | File extension     |
-| url         | String  | File access URL    |
-| downloadUrl | String  | File download URL  |
-| mimeType    | String  | MIME type          |
-| createdBy   | String  | Created by         |
-| createdAt   | Long    | Creation timestamp |
+| Parameter      | Type    | Description        |
+|----------------|---------|--------------------|
+| id             | String  | File ID            |
+| name           | String  | File name          |
+| size           | Integer | File size          |
+| extension      | String  | File extension     |
+| url            | String  | File access URL    |
+| downloadUrl    | String  | File download URL  |
+| mimeType       | String  | MIME type          |
+| createdBy      | String  | Created by         |
+| createdAt      | Long    | Creation timestamp |
+| previewUrl     | String  | Preview URL        |
+| sourceUrl      | String  | Source URL         |
+| originalUrl    | String  | Original URL       |
+| userId         | String  | User ID            |
+| tenantId       | String  | Tenant ID          |
+| conversationId | String  | Conversation ID    |
+| fileKey        | String  | File storage key   |
 
 ### 2.9 Update Document Status
 

--- a/docs/guide/feature/chat.md
+++ b/docs/guide/feature/chat.md
@@ -612,15 +612,22 @@ FileUploadResponse fileUpload(FileUploadRequest request);
 
 FileUploadResponse
 
-| 参数名       | 类型      | 描述       |
-|-----------|---------|----------|
-| id        | String  | 文件 id    |
-| name      | String  | 文件名称     |
-| size      | Integer | 文件大小(字节) |
-| extension | String  | 文件后缀     |
-| mimeType  | String  | 文件MIME类型 |
-| createdBy | String  | 创建人      |
-| createdAt | Long    | 创建时间戳    |
+| 参数名            | 类型      | 描述         |
+|----------------|---------|------------|
+| id             | String  | 文件 id      |
+| name           | String  | 文件名称       |
+| size           | Integer | 文件大小(字节)   |
+| extension      | String  | 文件后缀       |
+| mimeType       | String  | 文件MIME类型   |
+| createdBy      | String  | 创建人        |
+| createdAt      | Long    | 创建时间戳      |
+| previewUrl     | String  | 预览 URL     |
+| sourceUrl      | String  | 源 URL      |
+| originalUrl    | String  | 原始 URL     |
+| userId         | String  | 用户 ID      |
+| tenantId       | String  | 租户 ID      |
+| conversationId | String  | 会话 ID      |
+| fileKey        | String  | 文件存储键      |
 
 ### 3.5 获取应用信息
 

--- a/docs/guide/feature/dataset.md
+++ b/docs/guide/feature/dataset.md
@@ -684,17 +684,24 @@ UploadFileInfoResponse uploadFileInfo(String datasetId, String documentId, Strin
 
 UploadFileInfoResponse
 
-| 参数名         | 类型      | 描述      |
-|-------------|---------|---------|
-| id          | String  | 文件ID    |
-| name        | String  | 文件名     |
-| size        | Integer | 文件大小    |
-| extension   | String  | 文件扩展名   |
-| url         | String  | 文件访问URL |
-| downloadUrl | String  | 文件下载URL |
-| mimeType    | String  | MIME类型  |
-| createdBy   | String  | 创建人     |
-| createdAt   | Long    | 创建时间戳   |
+| 参数名            | 类型      | 描述         |
+|----------------|---------|------------|
+| id             | String  | 文件ID       |
+| name           | String  | 文件名        |
+| size           | Integer | 文件大小       |
+| extension      | String  | 文件扩展名      |
+| url            | String  | 文件访问URL    |
+| downloadUrl    | String  | 文件下载URL    |
+| mimeType       | String  | MIME类型     |
+| createdBy      | String  | 创建人        |
+| createdAt      | Long    | 创建时间戳      |
+| previewUrl     | String  | 预览 URL     |
+| sourceUrl      | String  | 源 URL      |
+| originalUrl    | String  | 原始 URL     |
+| userId         | String  | 用户 ID      |
+| tenantId       | String  | 租户 ID      |
+| conversationId | String  | 会话 ID      |
+| fileKey        | String  | 文件存储键      |
 
 ### 2.9 更新文档状态
 


### PR DESCRIPTION
feat: add new fields to file upload response DTOs

Add 7 new fields to FileUploadResponse and UploadFileInfoResponse to match the complete Dify API specification:
- previewUrl: Preview URL for the file
- sourceUrl: Source URL of the file
- originalUrl: Original URL of the file
- userId: User ID who uploaded the file
- tenantId: Tenant ID associated with the file
- conversationId: Conversation ID (nullable, for chat context)
- fileKey: File storage key/path

Changes:
- feat(chat): add 7 new fields to FileUploadResponse
- feat(dataset): add 7 new fields to UploadFileInfoResponse
- fix(dataset): correct typo in @JsonAlias from "mine_type" to "mime_type"
- test(chat): update FileUploadResponseTest to cover new fields
- test(dataset): create UploadFileInfoResponseTest with comprehensive coverage
- docs: update Chinese and English documentation for both response DTOs

All fields are nullable (optional) to maintain backward compatibility. Jackson automatically handles JSON deserialization for the new fields.

Breaking Changes:
- Equals/hashCode behavior changes due to new fields in DTOs
- Fixed mime_type alias (was incorrectly "mine_type")

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Resolves #333 

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`,
>
see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> for more details.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic
  change.
- [x] I've updated the documentation accordingly.
